### PR TITLE
Incorrect naming used in LoginUser.js

### DIFF
--- a/authentication-with-email-and-apollo/src/components/LoginUser.js
+++ b/authentication-with-email-and-apollo/src/components/LoginUser.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { withRouter } from 'react-router'
 import { graphql, gql, compose } from 'react-apollo'
 
-class CreateLogin extends React.Component {
+class LoginUser extends React.Component {
   
   state = {
     email: '',
@@ -73,4 +73,4 @@ const userQuery = gql`
 export default compose(
   graphql(signinUser, {name: 'signinUser'}),
   graphql(userQuery, { options: { fetchPolicy: 'network-only' }})
-)(withRouter(CreateLogin))
+)(withRouter(LoginUser))


### PR DESCRIPTION
In https://docs-next.graph.cool/tutorials/auth/authentication-with-email-and-password-for-react-and-apollo-cu3jah9ech/ and in this example's index.js used component naming:

> LoginUser

 not 

> CreateUser