### PR TITLE
remove graphql tag

### DIFF
--- a/advanced/src/components/CreatePage.js
+++ b/advanced/src/components/CreatePage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { withRouter } from 'react-router-dom'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 
 class CreatePage extends React.Component {
   state = {

--- a/advanced/src/components/DetailPage.js
+++ b/advanced/src/components/DetailPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { withRouter } from 'react-router-dom'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 
 class DetailPage extends React.Component {
   render() {

--- a/advanced/src/components/DraftsPage.js
+++ b/advanced/src/components/DraftsPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Post from '../components/Post'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 
 class DraftsPage extends React.Component {
   componentWillReceiveProps(nextProps) {

--- a/advanced/src/components/FeedPage.js
+++ b/advanced/src/components/FeedPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Post from '../components/Post'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 
 class FeedPage extends React.Component {
   componentWillReceiveProps(nextProps) {

--- a/advanced/src/components/LoginPage.js
+++ b/advanced/src/components/LoginPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { withRouter } from 'react-router-dom'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 import { AUTH_TOKEN } from '../constant'
 
 class LoginPage extends React.Component {

--- a/advanced/src/components/RootContainer.js
+++ b/advanced/src/components/RootContainer.js
@@ -18,7 +18,7 @@ import LogoutPage from './LogoutPage'
 import { AUTH_TOKEN } from '../constant'
 import { isTokenExpired } from '../helper/jwtHelper'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 
 const ProtectedRoute = ({ component: Component, token, ...rest }) => {
   return token ? (

--- a/advanced/src/components/SignupPage.js
+++ b/advanced/src/components/SignupPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { withRouter } from 'react-router-dom'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 import { AUTH_TOKEN } from '../constant'
 
 class SignupPage extends React.Component {

--- a/basic/package.json
+++ b/basic/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "apollo-boost": "0.1.4",
     "graphql": "0.13.2",
-    "graphql-tag": "2.8.0",
     "react": "16.3.1",
     "react-apollo": "2.1.3",
     "react-dom": "16.3.1",

--- a/basic/src/components/CreatePage.js
+++ b/basic/src/components/CreatePage.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router-dom'
 import { Mutation } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 import { DRAFTS_QUERY } from './DraftsPage'
 
 class CreatePage extends Component {

--- a/basic/src/components/DetailPage.js
+++ b/basic/src/components/DetailPage.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { Query, Mutation } from 'react-apollo'
 import { withRouter } from 'react-router-dom'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 import { DRAFTS_QUERY } from './DraftsPage'
 import { FEED_QUERY } from './FeedPage'
 

--- a/basic/src/components/DraftsPage.js
+++ b/basic/src/components/DraftsPage.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import Post from '../components/Post'
 import { Query } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 
 export default class DraftsPage extends Component {
   render() {

--- a/basic/src/components/FeedPage.js
+++ b/basic/src/components/FeedPage.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import Post from '../components/Post'
 import { Query } from 'react-apollo'
-import gql from 'graphql-tag'
+import  { gql } from 'apollo-boost'
 
 export default class FeedPage extends Component {
   render() {

--- a/basic/yarn.lock
+++ b/basic/yarn.lock
@@ -2932,7 +2932,7 @@ graphql-anywhere@^4.1.8:
   dependencies:
     apollo-utilities "^1.0.11"
 
-graphql-tag@2.8.0, graphql-tag@^2.4.2:
+graphql-tag@^2.4.2:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.8.0.tgz#52cdea07a842154ec11a2e840c11b977f9b835ce"
 

--- a/minimal/package.json
+++ b/minimal/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "apollo-boost": "0.1.4",
     "graphql": "0.13.2",
-    "graphql-tag": "2.8.0",
     "react": "16.3.1",
     "react-apollo": "2.1.3",
     "react-dom": "16.3.1",

--- a/minimal/src/components/App.js
+++ b/minimal/src/components/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import gql from 'graphql-tag'
+import { gql } from 'apollo-boost'
 import { Query } from 'react-apollo'
 import logo from '../logo.svg'
 import '../styles/App.css'

--- a/minimal/yarn.lock
+++ b/minimal/yarn.lock
@@ -3140,7 +3140,7 @@ graphql-anywhere@^4.1.8:
   dependencies:
     apollo-utilities "^1.0.11"
 
-graphql-tag@2.8.0, graphql-tag@^2.4.2:
+graphql-tag@^2.4.2:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.8.0.tgz#52cdea07a842154ec11a2e840c11b977f9b835ce"
 


### PR DESCRIPTION
closes #236 

All except the advanced that needs more stuff already has apollo boost.

All I did was remove graphql-tag as it already comes with apollo-boost