### PR TITLE
fix the Error: Duplicate "graphql" modules,  when running server

### DIFF
--- a/basic/package.json
+++ b/basic/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "apollo-boost": "0.1.16",
-    "graphql": "0.13.2",
+    "graphql": "1.9.4",
     "react": "16.5.2",
     "react-apollo": "2.2.4",
     "react-dom": "16.5.2",

--- a/basic/server/package.json
+++ b/basic/server/package.json
@@ -14,5 +14,9 @@
     "graphql-cli": "2.16.7",
     "npm-run-all": "4.1.3",
     "prisma": "1.7.1"
+  },
+  "resolutions": {
+    "graphql": "^0.13.0",
+    "**/graphql": "^0.13.0"
   }
 }


### PR DESCRIPTION
Referring to the solution

https://github.com/graphql-boilerplates/node-graphql-server/issues/211