### PR TITLE
fix(schema fields): fix schema fields on frontend

### DIFF
--- a/advanced/src/components/CreatePage.js
+++ b/advanced/src/components/CreatePage.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router-dom'
 import { graphql } from 'react-apollo'
-import  { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
 
 class CreatePage extends Component {
   state = {
     title: '',
-    text: '',
+    content: '',
   }
 
   render() {
@@ -25,16 +25,16 @@ class CreatePage extends Component {
           <textarea
             className="db w-100 ba bw1 b--black-20 pa2 br2 mb2"
             cols={50}
-            onChange={e => this.setState({ text: e.target.value })}
+            onChange={e => this.setState({ content: e.target.value })}
             placeholder="Content"
             rows={8}
-            value={this.state.text}
+            value={this.state.content}
           />
           <input
-            className={`pa3 bg-black-10 bn ${this.state.text &&
+            className={`pa3 bg-black-10 bn ${this.state.content &&
               this.state.title &&
               'dim pointer'}`}
-            disabled={!this.state.text || !this.state.title}
+            disabled={!this.state.content || !this.state.title}
             type="submit"
             value="Create"
           />
@@ -48,20 +48,20 @@ class CreatePage extends Component {
 
   handlePost = async e => {
     e.preventDefault()
-    const { title, text } = this.state
+    const { title, content } = this.state
     await this.props.createDraftMutation({
-      variables: { title, text },
+      variables: { title, content },
     })
     this.props.history.replace('/drafts')
   }
 }
 
 const CREATE_DRAFT_MUTATION = gql`
-  mutation CreateDraftMutation($title: String!, $text: String!) {
-    createDraft(title: $title, text: $text) {
+  mutation CreateDraftMutation($title: String!, $content: String!) {
+    createDraft(title: $title, content: $content) {
       id
       title
-      text
+      content
     }
   }
 `

--- a/advanced/src/components/DetailPage.js
+++ b/advanced/src/components/DetailPage.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
 import { withRouter } from 'react-router-dom'
-import  { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
 
 class DetailPage extends Component {
   render() {
@@ -20,14 +20,14 @@ class DetailPage extends Component {
     return (
       <Fragment>
         <h1 className="f3 black-80 fw4 lh-solid">{post.title}</h1>
-        <p className="black-80 fw3">{post.text}</p>
+        <p className="black-80 fw3">{post.content}</p>
         {action}
       </Fragment>
     )
   }
 
-  _renderAction = ({ id, isPublished }) => {
-    if (!isPublished) {
+  _renderAction = ({ id, published }) => {
+    if (!published) {
       return (
         <Fragment>
           <a
@@ -75,8 +75,8 @@ const POST_QUERY = gql`
     post(id: $id) {
       id
       title
-      text
-      isPublished
+      content
+      published
       author {
         name
       }
@@ -88,7 +88,7 @@ const PUBLISH_MUTATION = gql`
   mutation publish($id: ID!) {
     publish(id: $id) {
       id
-      isPublished
+      published
     }
   }
 `

--- a/advanced/src/components/DraftsPage.js
+++ b/advanced/src/components/DraftsPage.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import Post from '../components/Post'
 import { graphql } from 'react-apollo'
-import  { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
 
 class DraftsPage extends Component {
   componentWillReceiveProps(nextProps) {
@@ -30,7 +30,7 @@ class DraftsPage extends Component {
               key={draft.id}
               post={draft}
               refresh={() => this.props.draftsQuery.refetch()}
-              isDraft={!draft.isPublished}
+              isDraft={!draft.published}
             />
           ))}
         {this.props.children}
@@ -43,9 +43,9 @@ const DRAFTS_QUERY = gql`
   query DraftsQuery {
     drafts {
       id
-      text
+      content
       title
-      isPublished
+      published
       author {
         name
       }

--- a/advanced/src/components/FeedPage.js
+++ b/advanced/src/components/FeedPage.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import Post from '../components/Post'
 import { graphql } from 'react-apollo'
-import  { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
 
 class FeedPage extends Component {
   componentWillReceiveProps(nextProps) {
@@ -32,7 +32,7 @@ class FeedPage extends Component {
               key={post.id}
               post={post}
               refresh={() => this.props.feedQuery.refetch()}
-              isDraft={!post.isPublished}
+              isDraft={!post.published}
             />
           ))}
         {this.props.children}
@@ -45,9 +45,9 @@ const FEED_QUERY = gql`
   query FeedQuery {
     feed {
       id
-      text
+      content
       title
-      isPublished
+      published
       author {
         name
       }
@@ -59,9 +59,9 @@ const FEED_SUBSCRIPTION = gql`
     feedSubscription {
       node {
         id
-        text
+        content
         title
-        isPublished
+        published
         author {
           name
         }

--- a/advanced/src/components/Post.js
+++ b/advanced/src/components/Post.js
@@ -14,7 +14,7 @@ export default class Post extends Component {
           <div className="flex flex-column flex-row-ns">
             <div className="w-100 w-60-ns pl3-ns">
               <h1 className="f3 fw1 baskerville mt0 lh-title">{title}</h1>
-              <p className="f6 f5-l lh-copy">{this.props.post.text}</p>
+              <p className="f6 f5-l lh-copy">{this.props.post.content}</p>
               <p className="f6 lh-copy mv0">By {this.props.post.author.name}</p>
             </div>
           </div>


### PR DESCRIPTION
fields text and isPublished are renamed to be the same as fields on backend (content and published), several pages (Create, Detail, Drafts, Feed, Post) didn't work properly before this improvement 